### PR TITLE
Fix namespaces for API controllers

### DIFF
--- a/app/Http/Controllers/Api/ApplicationNoteController.php
+++ b/app/Http/Controllers/Api/ApplicationNoteController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\API;
+namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\ApplicationNote;

--- a/app/Http/Controllers/Api/AuditLogController.php
+++ b/app/Http/Controllers/Api/AuditLogController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\API;
+namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\AuditLog;

--- a/app/Http/Controllers/Api/CommunicationController.php
+++ b/app/Http/Controllers/Api/CommunicationController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\API;
+namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\Communication;

--- a/app/Http/Controllers/Api/DiaryReminderController.php
+++ b/app/Http/Controllers/Api/DiaryReminderController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\API;
+namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\DiaryReminder;

--- a/app/Http/Controllers/Api/ExpenseStatementController.php
+++ b/app/Http/Controllers/Api/ExpenseStatementController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\API;
+namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\ExpenseStatement;

--- a/app/Http/Controllers/Api/FirstContactController.php
+++ b/app/Http/Controllers/Api/FirstContactController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\API;
+namespace App\Http\Controllers\Api;
 
 use App\Models\FirstContact;
 use App\Http\Controllers\Controller;

--- a/app/Http/Controllers/Api/UserRoleController.php
+++ b/app/Http/Controllers/Api/UserRoleController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\API;
+namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\User;

--- a/app/Http/Controllers/Api/VerbalContactController.php
+++ b/app/Http/Controllers/Api/VerbalContactController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\API;
+namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\VerbalContact;


### PR DESCRIPTION
## Summary
- correct namespace definitions across API controllers for PSR-4 autoloading compliance

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845dd3f3100832796611f9486efacab