### PR TITLE
Fix CI PHP version for tests

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup PHP with extensions
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.0'
+          php-version: '8.2'
           extensions: mbstring, bcmath, sqlite, pdo_sqlite
           coverage: none
 


### PR DESCRIPTION
## Summary
- update CI PHP version to 8.2 to match project requirements

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6845e5c68dc083278133ec80b0411ad4