### PR TITLE
Fix npm installation in workflow

### DIFF
--- a/.github/workflows/master_guardian-connect.yml
+++ b/.github/workflows/master_guardian-connect.yml
@@ -41,7 +41,12 @@ jobs:
           node-version: '20'
 
       - name: Install npm dependencies
-        run: npm ci
+        run: |
+          if [ -f package-lock.json ]; then
+            npm ci
+          else
+            npm install
+          fi
 
       - name: Build assets
         run: npm run build


### PR DESCRIPTION
## Summary
- prevent failing builds by installing with `npm install` when `package-lock.json` is absent

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm ci` *(fails: requires existing lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6848525c7a088327bab1cd1c8546bc95