### PR TITLE
Add Firebase integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,4 +63,9 @@ AWS_DEFAULT_REGION=us-east-1
 AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
+# Firebase configuration
+FIREBASE_CREDENTIALS=/path/to/firebase_credentials.json
+FIREBASE_DATABASE_URL=https://your-project.firebaseio.com
+FIREBASE_STORAGE_BUCKET=your-project.appspot.com
+
 VITE_APP_NAME="${APP_NAME}"

--- a/README.md
+++ b/README.md
@@ -64,3 +64,16 @@ If you discover a security vulnerability within Laravel, please send an e-mail t
 ## License
 
 The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+
+## Firebase Integration
+
+This project uses Firebase for authentication, push notifications and file storage.
+Configure the following environment variables in your `.env` file:
+
+```
+FIREBASE_CREDENTIALS=/path/to/firebase_credentials.json
+FIREBASE_DATABASE_URL=https://your-project.firebaseio.com
+FIREBASE_STORAGE_BUCKET=your-project.appspot.com
+```
+
+Use the `/api/login/firebase` endpoint to authenticate with a Firebase ID token.

--- a/app/Http/Controllers/Api/NotificationController.php
+++ b/app/Http/Controllers/Api/NotificationController.php
@@ -7,9 +7,16 @@ use App\Mail\StateResourcesMail;
 use App\Models\Application;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Http\Request;
+use App\Services\FirebaseService;
 
 class NotificationController extends Controller
 {
+    protected FirebaseService $firebase;
+
+    public function __construct(FirebaseService $firebase)
+    {
+        $this->firebase = $firebase;
+    }
     /**
      * Send State Resources Letter
      */
@@ -19,6 +26,12 @@ class NotificationController extends Controller
 
         Mail::to($application->applicant->email)
             ->send(new StateResourcesMail($application));
+
+        if ($application->applicant->fcm_token) {
+            $this->firebase->sendPush([
+                $application->applicant->fcm_token
+            ], 'New Letter Available', 'A state resources letter was sent to you.');
+        }
 
         return response()->json(['message' => 'State Resources Letter sent successfully.']);
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -16,6 +16,7 @@ class User extends Authenticatable
         'email',
         'password',
         'role', // This allows mass assignment for role
+        'fcm_token',
     ];
 
     protected $hidden = [

--- a/app/Services/FirebaseService.php
+++ b/app/Services/FirebaseService.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Services;
+
+use Kreait\Laravel\Firebase\Facades\Firebase;
+use Kreait\Firebase\Contract\Auth;
+use Kreait\Firebase\Contract\Storage;
+use Kreait\Firebase\Contract\Messaging;
+use Kreait\Firebase\Messaging\CloudMessage;
+
+class FirebaseService
+{
+    protected Auth $auth;
+    protected Storage $storage;
+    protected Messaging $messaging;
+
+    public function __construct()
+    {
+        $this->auth = Firebase::auth();
+        $this->storage = Firebase::storage();
+        $this->messaging = Firebase::messaging();
+    }
+
+    public function verifyIdToken(string $idToken)
+    {
+        try {
+            return $this->auth->verifyIdToken($idToken);
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }
+
+    public function upload(string $fileName, $content)
+    {
+        $bucket = $this->storage->getBucket();
+        $object = $bucket->upload($content, ['name' => $fileName]);
+        return $object->signedUrl(new \DateTime('+1 hour'));
+    }
+
+    public function sendPush(array $tokens, string $title, string $body)
+    {
+        $message = CloudMessage::new()->withNotification(["title" => $title, "body" => $body]);
+        $this->messaging->sendMulticast($message, $tokens);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "laravel/sanctum": "^4.0",
         "laravel/socialite": "^5.18",
         "laravel/tinker": "^2.9"
+        ,"kreait/laravel-firebase": "^4.0"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/config/app.php
+++ b/config/app.php
@@ -100,6 +100,7 @@ return [
      * Package Service Providers...
      */
     Barryvdh\DomPDF\ServiceProvider::class, // DomPDF
+    Kreait\Laravel\Firebase\ServiceProvider::class,
 
     /*
      * Application Service Providers...
@@ -145,6 +146,7 @@ return [
     'URL' => Illuminate\Support\Facades\URL::class,
     'Validator' => Illuminate\Support\Facades\Validator::class,
     'View' => Illuminate\Support\Facades\View::class,
+    'Firebase' => Kreait\Laravel\Firebase\Facades\Firebase::class,
 ],
 
 

--- a/config/firebase.php
+++ b/config/firebase.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'credentials' => env('FIREBASE_CREDENTIALS'),
+    'database_url' => env('FIREBASE_DATABASE_URL'),
+    'storage_bucket' => env('FIREBASE_STORAGE_BUCKET'),
+];

--- a/database/migrations/2025_05_01_000000_add_fcm_token_to_users_table.php
+++ b/database/migrations/2025_05_01_000000_add_fcm_token_to_users_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (!Schema::hasColumn('users', 'fcm_token')) {
+                $table->text('fcm_token')->nullable()->after('remember_token');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('fcm_token');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -21,6 +21,7 @@ Route::get('/sanctum/csrf-cookie', [CsrfCookieController::class, 'show']);
 
 // Public Authentication Routes
 Route::post('/login', [AuthController::class, 'login']);
+Route::post('/login/firebase', [AuthController::class, 'loginWithFirebase']);
 Route::post('/signup', [AuthController::class, 'signup']);
 Route::get('/auth/google', [AuthController::class, 'redirectToGoogle']);
 Route::get('/auth/google/callback', [AuthController::class, 'handleGoogleCallback']);


### PR DESCRIPTION
## Summary
- integrate `kreait/laravel-firebase`
- add FirebaseService wrapper
- enable Firebase provider and alias
- add Firebase config and env vars
- support login via Firebase token
- store FCM token in users
- send push notifications when sending state resources letter
- document Firebase setup

## Testing
- `composer install` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863455c22688327abaffe0ebcdab35a